### PR TITLE
Fix Unit Tests

### DIFF
--- a/MTGSDKSwift/MTGAPIManager.swift
+++ b/MTGSDKSwift/MTGAPIManager.swift
@@ -33,8 +33,8 @@ final class URLManager {
         
         urlComponents.queryItems = buildQueryItemsFromParameters(parameters)
         
-        if Magic.enableLogging == true {
-            print("URL: \(urlComponents.url)\n")
+        if Magic.enableLogging == true, let url = urlComponents.url {
+            print("URL: \(url)\n")
         }
         
         return urlComponents.url


### PR DESCRIPTION
### Background
I found the unit tests to have issues for a variety of reasons (see [Issue #3](https://github.com/MagicTheGathering/mtg-sdk-swift/issues/3))

### Updates
- [x] Fixed a warning in `MTGAPIManager.swift`
- [x] Refactored `MTGSDKSwiftTests.swift` so that:
    - Makes use of the `expectation` API so that the test functions wait for the callbacks to execute
    - Each test function is responsible for its own setup and no longer rely on running in a specific order
    - Replaces use of `assert` with `XCTAssertTrue` / `XCTAssertNil` / `XCTAssertNotNil` etc
    - Makes use of `defer` / `guards` to help prevent logic bugs in the callback blocks
    - Reorganized the tests with extensions to organize them more logically for readability